### PR TITLE
Require mb_string extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     },
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.1",


### PR DESCRIPTION
Added php mb_string extension as dependency in composer.json as proposed in #31 
