### PR TITLE
New Line for Test Case ignored

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -45,11 +45,11 @@ class Printer extends \PHPUnit_TextUI_ResultPrinter
     ) {
         parent::__construct($out, $verbose, $colors, $debug, $numberOfColumns);
 
-        $this->maxNumberOfColumns = $numberOfColumns;
         if ($numberOfColumns === 'max') {
             $console = new Console();
             $numberOfColumns = $console->getNumberOfColumns();
         }
+        $this->maxNumberOfColumns = $numberOfColumns;
 
         $this->maxClassNameLength = intval($numberOfColumns * 0.6);
     }

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -88,7 +88,7 @@ class Printer extends \PHPUnit_TextUI_ResultPrinter
      */
     private function printTestCaseStatus($color, $buffer)
     {
-        if ($this->column == $this->maxNumberOfColumns) {
+        if ($this->column >= $this->maxNumberOfColumns) {
             $this->writeNewLine();
             $padding = $this->maxClassNameLength;
             $this->column = $padding;
@@ -141,7 +141,7 @@ class Printer extends \PHPUnit_TextUI_ResultPrinter
         } else {
             $this->write($className);
         }
-        $this->column += strlen($className) + 4;
+        $this->column = strlen($className) + 4;
         echo "\t";
 
         $this->lastClassName = $this->className;

--- a/tests/lots-of-asserts/__files/SecondPrinterTest.php
+++ b/tests/lots-of-asserts/__files/SecondPrinterTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace PrettyResultPrinterTest;
+
+class SecondPrinterTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testTestCaseNameIsDisplayed()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest1()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest2()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest3()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest4()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest5()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest6()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest7()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest8()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest9()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest10()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest11()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest12()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest13()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest14()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest15()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest16()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest17()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest18()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest19()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest20()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest21()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest22()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest23()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest24()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest25()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest26()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest27()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest28()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest29()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest30()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest31()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest32()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest33()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest34()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest35()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest36()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest37()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest38()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest39()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest40()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest41()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest42()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest43()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest44()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest45()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest46()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest47()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest48()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest49()
+    {
+        $this->assertTrue(true);
+    }
+    public function testTest50()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/lots-of-asserts/issue-36.phpt
+++ b/tests/lots-of-asserts/issue-36.phpt
@@ -1,5 +1,6 @@
 --TEST--
-php vendor/bin/phpunit -c phpunit.xml
+php vendor/bin/phpunit -c phpunit.xml __files/
+UnitTest for Issue #36
 --FILE--
 <?php
 $_SERVER['TERM']    = 'linux';

--- a/tests/lots-of-asserts/issue-36.phpt
+++ b/tests/lots-of-asserts/issue-36.phpt
@@ -1,0 +1,24 @@
+--TEST--
+php vendor/bin/phpunit -c phpunit.xml
+--FILE--
+<?php
+$_SERVER['TERM']    = 'linux';
+$_SERVER['argv'][1] = '-c';
+$_SERVER['argv'][2] = dirname(__FILE__) . '/__files/phpunit.xml';
+$_SERVER['argv'][3] = dirname(__FILE__) . '/__files/';
+
+require_once dirname(dirname(dirname(__FILE__))) . '/vendor/autoload.php';
+
+PHPUnit_TextUI_Command::main();
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+
+PrettyResultPrinterTest\PrinterTest             	✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
+                                                	✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
+PrettyResultPrinterTest\SecondPrinterTest       	✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
+                                                	✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
+
+Time: %s ms, Memory: %sMb
+
+OK (102 tests, 102 assertions)


### PR DESCRIPTION
When executing multiple test classes with a lot of test cases, the new Lines are ignored.

Fix for #36 
